### PR TITLE
fix(patch/theme): apply to correct file

### DIFF
--- a/eos-theme.patch
+++ b/eos-theme.patch
@@ -3,10 +3,10 @@ Date:   Wed Jan 30 09:22:04 2019 -0200
 
     patch for forcing elementary os theme and icons
 
-diff --git a/src/Application.vala b/src/Application.vala
+diff --git a/src/MainWindow.vala b/src/MainWindow.vala
 index a848f7e..f85b53b 100644
---- a/src/Application.vala
-+++ b/src/Application.vala
+--- a/src/MainWindow.vala
++++ b/src/MainWindow.vala
 @@ -61,6 +61,9 @@ namespace GiveMeLyrics {
                  () => {
                      Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = settings.use_dark_theme;


### PR DESCRIPTION
Build is currently broken because the patch can't be applied (it's out of date), which is probably why https://flathub.org/apps/details/com.github.muriloventuroso.givemelyrics is still at `0.4.0`, even though this repository is at `0.5.0`.